### PR TITLE
Replace deprecated scipy.interp2d with RectBivariateSpline

### DIFF
--- a/stmpy/driftcorr.py
+++ b/stmpy/driftcorr.py
@@ -10,7 +10,7 @@ import matplotlib as mpl
 import matplotlib.pyplot as plt
 import scipy.optimize as opt
 import scipy.ndimage as snd
-from scipy.interpolate import interp1d, interp2d
+from scipy.interpolate import interp1d, interp2d, RectBivariateSpline
 from skimage import transform as tf
 from skimage.feature import peak_local_max
 from pprint import pprint
@@ -1177,14 +1177,17 @@ def cropedge_new(A, n, bp=None, c1=2, c2=2,
         t1 = np.arange(L1)
         t2 = np.arange(L2)
         if len(np.shape(A)) == 2:
-            f = interp2d(t1, t2, B, kind='cubic')
+            #f = interp2d(t1, t2, B, kind='cubic')
+            #f = interp2d()
+            f = RectBivariateSpline(t1, t2, B.T, kx=3, ky=3) # transposed vs interp2d, and defining cubic w/ kx=ky=3
             t_new1 = np.linspace(0, L_new1, num=L1+1)
             t_new2 = np.linspace(0, L_new2, num=L2+1)
             z_new = f(t_new1[:-1], t_new2[:-1])
         elif len(np.shape(A)) == 3:
             z_new = np.zeros([np.shape(A)[0], L2, L1])
             for i in range(len(A)):
-                f = interp2d(t1, t2, B[i], kind='cubic')
+                #f = interp2d(t1, t2, B[i], kind='cubic')
+                f = RectBivariateSpline(t1, t2, B[i].T, kx=3, ky=3)
                 t_new1 = np.linspace(0, L_new1, num=L1+1)
                 t_new2 = np.linspace(0, L_new2, num=L2+1)
                 z_new[i] = f(t_new1[:-1], t_new2[:-1])
@@ -1273,7 +1276,8 @@ def __cropedge(A, n, bp=None, c1=2, c2=2, a1=None, a2=None, force_commen=False):
         t1 = np.arange(L1)
         t2 = np.arange(L2)
         if len(np.shape(A)) == 2:
-            f = interp2d(t1, t2, B, kind='cubic')
+            #f = interp2d(t1, t2, B, kind='cubic')
+            f = RectBivariateSpline(t1, t2, B.T, kx=3, ky=3)
             t_new1 = np.linspace(delta1, L_new1+delta1, num=L1-offset+1)
             t_new2 = np.linspace(delta2, L_new2+delta2, num=L2-offset+1)
             #t_new1 = np.linspace(0, L_new1, num=L1-offset+1)
@@ -1282,7 +1286,8 @@ def __cropedge(A, n, bp=None, c1=2, c2=2, a1=None, a2=None, force_commen=False):
         elif len(np.shape(A)) == 3:
             z_new = np.zeros([np.shape(A)[0], L2-offset, L1-offset])
             for i in range(len(A)):
-                f = interp2d(t1, t2, B[i], kind='cubic')
+                #f = interp2d(t1, t2, B[i], kind='cubic')
+                f = RectBivariateSpline(t1, t2, B[i].T, kx=3, ky=3)
                 t_new1 = np.linspace(delta1, L_new1+delta1, num=L1-offset+1)
                 t_new2 = np.linspace(delta2, L_new2+delta2, num=L2-offset+1)
                 z_new[i] = f(t_new1[:-1], t_new2[:-1])
@@ -1516,6 +1521,7 @@ def driftcorr(A, ux=None, uy=None, method="lockin", interpolation='cubic'):
                                                     (x-ux, y-uy)
                                     "convolution": Used inversion fft to apply the drift fields
         interpolation - Optional : Specifying which method to use for interpolating
+                                    (originally followed interp2d, now translating into kx and ky for RectBilinear)
 
     Returns:
         A_corr      - 2D or 3D array of topo with drift corrected
@@ -1539,14 +1545,28 @@ def driftcorr(A, ux=None, uy=None, method="lockin", interpolation='cubic'):
         ynew = (y - uy).ravel()
         tmp = np.zeros(s1*s2)
         if len(A.shape) is 2:
-            tmp_f = interp2d(t1, t2, A, kind=interpolation)
+            #tmp_f = interp2d(t1, t2, A, kind=interpolation)
+            if(interpolation == 'cubic'):
+                tmp_f = RectBivariateSpline(t1, t2, A.T, kx=3, ky=3) # cubic kx=ky=3
+            elif(interpolation == 'linear'):
+                tmp_f = RectBivariateSpline(t1, t2, A.T, kx=1, ky=1) # linear kx=ky=1
+            else:
+                raise ValueError(f"invalid interpolation given: {interpolation}")
+            
             for ix in range(tmp.size):
                 tmp[ix] = tmp_f(xnew[ix], ynew[ix])
             A_corr = tmp.reshape(s2, s1)
             return A_corr
         elif len(A.shape) is 3:
             for iz, layer in enumerate(A):
-                tmp_f = interp2d(t1, t2, layer, kind=interpolation)
+                #tmp_f = interp2d(t1, t2, layer, kind=interpolation)
+                if(interpolation == 'cubic'):
+                    tmp_f = RectBivariateSpline(t1, t2, layer.T, kx=3, ky=3) # cubic kx=ky=3
+                elif(interpolation == 'linear'):
+                    tmp_f = RectBivariateSpline(t1, t2, layer.T, kx=1, ky=1) # linear kx=ky=1
+                else:
+                    raise ValueError(f"invalid interpolation given: {interpolation}")
+                
                 for ix in range(tmp.size):
                     tmp[ix] = tmp_f(xnew[ix], ynew[ix])
                 A_corr[iz] = tmp.reshape(s2, s1)

--- a/stmpy/driftcorr.py
+++ b/stmpy/driftcorr.py
@@ -10,7 +10,7 @@ import matplotlib as mpl
 import matplotlib.pyplot as plt
 import scipy.optimize as opt
 import scipy.ndimage as snd
-from scipy.interpolate import interp1d, interp2d, RectBivariateSpline
+from scipy.interpolate import interp1d, RectBivariateSpline
 from skimage import transform as tf
 from skimage.feature import peak_local_max
 from pprint import pprint
@@ -1177,8 +1177,6 @@ def cropedge_new(A, n, bp=None, c1=2, c2=2,
         t1 = np.arange(L1)
         t2 = np.arange(L2)
         if len(np.shape(A)) == 2:
-            #f = interp2d(t1, t2, B, kind='cubic')
-            #f = interp2d()
             f = RectBivariateSpline(t1, t2, B.T, kx=3, ky=3) # transposed vs interp2d, and defining cubic w/ kx=ky=3
             t_new1 = np.linspace(0, L_new1, num=L1+1)
             t_new2 = np.linspace(0, L_new2, num=L2+1)
@@ -1186,7 +1184,6 @@ def cropedge_new(A, n, bp=None, c1=2, c2=2,
         elif len(np.shape(A)) == 3:
             z_new = np.zeros([np.shape(A)[0], L2, L1])
             for i in range(len(A)):
-                #f = interp2d(t1, t2, B[i], kind='cubic')
                 f = RectBivariateSpline(t1, t2, B[i].T, kx=3, ky=3)
                 t_new1 = np.linspace(0, L_new1, num=L1+1)
                 t_new2 = np.linspace(0, L_new2, num=L2+1)
@@ -1276,7 +1273,6 @@ def __cropedge(A, n, bp=None, c1=2, c2=2, a1=None, a2=None, force_commen=False):
         t1 = np.arange(L1)
         t2 = np.arange(L2)
         if len(np.shape(A)) == 2:
-            #f = interp2d(t1, t2, B, kind='cubic')
             f = RectBivariateSpline(t1, t2, B.T, kx=3, ky=3)
             t_new1 = np.linspace(delta1, L_new1+delta1, num=L1-offset+1)
             t_new2 = np.linspace(delta2, L_new2+delta2, num=L2-offset+1)
@@ -1286,7 +1282,6 @@ def __cropedge(A, n, bp=None, c1=2, c2=2, a1=None, a2=None, force_commen=False):
         elif len(np.shape(A)) == 3:
             z_new = np.zeros([np.shape(A)[0], L2-offset, L1-offset])
             for i in range(len(A)):
-                #f = interp2d(t1, t2, B[i], kind='cubic')
                 f = RectBivariateSpline(t1, t2, B[i].T, kx=3, ky=3)
                 t_new1 = np.linspace(delta1, L_new1+delta1, num=L1-offset+1)
                 t_new2 = np.linspace(delta2, L_new2+delta2, num=L2-offset+1)
@@ -1545,13 +1540,12 @@ def driftcorr(A, ux=None, uy=None, method="lockin", interpolation='cubic'):
         ynew = (y - uy).ravel()
         tmp = np.zeros(s1*s2)
         if len(A.shape) is 2:
-            #tmp_f = interp2d(t1, t2, A, kind=interpolation)
             if(interpolation == 'cubic'):
                 tmp_f = RectBivariateSpline(t1, t2, A.T, kx=3, ky=3) # cubic kx=ky=3
             elif(interpolation == 'linear'):
                 tmp_f = RectBivariateSpline(t1, t2, A.T, kx=1, ky=1) # linear kx=ky=1
             else:
-                raise ValueError(f"invalid interpolation given: {interpolation}")
+                raise ValueError(f"unsupported interpolation given: {interpolation}")
             
             for ix in range(tmp.size):
                 tmp[ix] = tmp_f(xnew[ix], ynew[ix])
@@ -1559,13 +1553,12 @@ def driftcorr(A, ux=None, uy=None, method="lockin", interpolation='cubic'):
             return A_corr
         elif len(A.shape) is 3:
             for iz, layer in enumerate(A):
-                #tmp_f = interp2d(t1, t2, layer, kind=interpolation)
                 if(interpolation == 'cubic'):
                     tmp_f = RectBivariateSpline(t1, t2, layer.T, kx=3, ky=3) # cubic kx=ky=3
                 elif(interpolation == 'linear'):
                     tmp_f = RectBivariateSpline(t1, t2, layer.T, kx=1, ky=1) # linear kx=ky=1
                 else:
-                    raise ValueError(f"invalid interpolation given: {interpolation}")
+                    raise ValueError(f"unsupported interpolation: {interpolation}")
                 
                 for ix in range(tmp.size):
                     tmp[ix] = tmp_f(xnew[ix], ynew[ix])

--- a/stmpy/tools.py
+++ b/stmpy/tools.py
@@ -61,9 +61,9 @@ def interp2d(x, y, z, kind='nearest', **kwargs):
         #return scinterp2d(x, y, z, kind=kind, **kwargs)
         from scipy.interpolate import RectBivariateSpline
         if(kind == 'cubic'):
-            return RectBivariateSpline(t1, t2, A.T, kx=3, ky=3) # cubic kx=ky=3
+            return RectBivariateSpline(x, y, z.T, kx=3, ky=3) # cubic kx=ky=3
         if(kind == 'linear'):
-            return RectBivariateSpline(t1, t2, A.T, kx=1, ky=1) # linear kx=ky=1
+            return RectBivariateSpline(x, y, z.T, kx=1, ky=1) # linear kx=ky=1
         else:
             raise ValueError(f"invalid interpolation given: {kind}")
         

--- a/stmpy/tools.py
+++ b/stmpy/tools.py
@@ -57,15 +57,13 @@ def interp2d(x, y, z, kind='nearest', **kwargs):
             return values.reshape(lx, ly)
         return fCall
     else:
-        #from scipy.interpolate import interp2d as scinterp2d
-        #return scinterp2d(x, y, z, kind=kind, **kwargs)
         from scipy.interpolate import RectBivariateSpline
         if(kind == 'cubic'):
             return RectBivariateSpline(x, y, z.T, kx=3, ky=3) # cubic kx=ky=3
         if(kind == 'linear'):
             return RectBivariateSpline(x, y, z.T, kx=1, ky=1) # linear kx=ky=1
         else:
-            raise ValueError(f"invalid interpolation given: {kind}")
+            raise ValueError(f"unsupported interpolation given: {kind}")
         
 
 def azimuthalAverage(F, x0, y0, r, theta=np.linspace(0,2*np.pi,500),

--- a/stmpy/tools.py
+++ b/stmpy/tools.py
@@ -57,9 +57,16 @@ def interp2d(x, y, z, kind='nearest', **kwargs):
             return values.reshape(lx, ly)
         return fCall
     else:
-        from scipy.interpolate import interp2d as scinterp2d
-        return scinterp2d(x, y, z, kind=kind, **kwargs)
-
+        #from scipy.interpolate import interp2d as scinterp2d
+        #return scinterp2d(x, y, z, kind=kind, **kwargs)
+        from scipy.interpolate import RectBivariateSpline
+        if(kind == 'cubic'):
+            return RectBivariateSpline(t1, t2, A.T, kx=3, ky=3) # cubic kx=ky=3
+        if(kind == 'linear'):
+            return RectBivariateSpline(t1, t2, A.T, kx=1, ky=1) # linear kx=ky=1
+        else:
+            raise ValueError(f"invalid interpolation given: {kind}")
+        
 
 def azimuthalAverage(F, x0, y0, r, theta=np.linspace(0,2*np.pi,500),
         kind='linear'):


### PR DESCRIPTION
interp2d was recently deprecated

since we have evenly-spaced input data, I'm replacing interp2d with RectBivariateSpline as recommended here: https://docs.scipy.org/doc/scipy/tutorial/interpolate/interp_transition_guide.html#interp2d-on-a-regular-grid 

cubic -> kx=ky=3
linear -> kx=ky=1

fixes #1 